### PR TITLE
Add sticky comment GitHub Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Post sticky comment (first)
+        uses: ./
+        with:
+          key: 'test-pr-comment'
+          body: test comment (will be updated with next step)
+
       - name: Post sticky comment
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test Sticky Comment
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  test-comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post sticky comment
+        uses: ./
+        with:
+          key: 'test-pr-comment'
+          body: |
+            ## 🧪 Test Comment
+
+            This is a test of the sticky comment action!
+
+            - PR Number: #${{ github.event.pull_request.number }}
+            - SHA: ${{ github.event.pull_request.head.sha }}
+            - Timestamp: ${{ github.event.pull_request.updated_at }}
+
+            This comment should update on each push, not create duplicates.
+
+      - name: Post another sticky comment with different key
+        uses: ./
+        with:
+          key: 'build-info'
+          body: |
+            ## 📦 Build Information
+
+            - Branch: ${{ github.head_ref }}
+            - Base: ${{ github.base_ref }}
+            - Actor: @${{ github.actor }}
+
+            Testing template escaping: {{ this should not be interpreted as a template }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
+
       - name: Post sticky comment
         uses: ./
         with:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 haya14busa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,73 @@
+# Sticky Comment Action
+
+A GitHub Action to post sticky comments to pull requests or issues.
+
+## Features
+
+- Post sticky comments that automatically update instead of creating duplicates
+- Support for both pull requests and issues
+- Auto-detects PR/Issue number from GitHub context
+- Unique key-based comment identification for updates
+
+## Usage
+
+```yaml
+name: PR Comment
+
+on:
+  pull_request:
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post sticky comment
+        uses: actionutils/sticky-comment@main
+        with:
+          key: 'build-status'
+          body: |
+            ## Build Status
+            ✅ All checks passed!
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `key` | Unique key for the sticky comment (used for updating) | Yes | - |
+| `body` | Comment body content | Yes | - |
+| `number` | PR or Issue number. If not provided, auto-detected from context | No | - |
+| `token` | GitHub token | No | `${{ github.token }}` |
+
+## How It Works
+
+This action is a handy wrapper around the [github-comment](https://github.com/suzuki-shunsuke/github-comment) CLI. It simplifies the usage by:
+
+- **Handling template escaping automatically**: You can pass any comment body directly without worrying about Go template syntax. The action properly escapes your content using `AvoidHTMLEscape` so special characters like `{{`, `}}`, and Go template syntax in your markdown won't be interpreted as templates.
+- **Providing a simple interface**: Just pass the `key` and `body` - no need to write complex template configurations or update conditions.
+- **Managing sticky comments**: Uses the key-based update condition to ensure comments are updated rather than duplicated.
+
+When you post a comment with a specific `key`, the action will:
+
+1. Check if a comment with the same key already exists
+2. If it exists, update the existing comment
+3. If it doesn't exist, create a new comment
+
+This ensures that repeated runs of the action won't spam the PR/Issue with duplicate comments.
+
+**Note:** The action uses `--pr` flag which works for both pull requests and issues.
+
+## Permissions
+
+The action requires appropriate permissions based on the target:
+
+- For **pull requests**: `pull-requests: write`
+- For **issues**: `issues: write`
+
+Make sure to set the correct permissions in your workflow file.
+
+## License
+
+MIT

--- a/action.yml
+++ b/action.yml
@@ -34,10 +34,18 @@ runs:
         ACTION_PATH: ${{ github.action_path }}
       run: |
         set -x  # Show executed commands for debugging
+
+        # Create temp file for comment body
+        TMPFILE=$(mktemp)
+        echo "${COMMENT_BODY}" > "${TMPFILE}"
+
         # Run github-comment
         "${ACTION_PATH}/run-github-comment.sh" -- post \
           --pr "${COMMENT_NUMBER:-0}" \
           -k "${COMMENT_KEY}" \
           --update-condition "Comment.HasMeta && Comment.Meta.TemplateKey == \"${COMMENT_KEY}\"" \
-          --var "content:${COMMENT_BODY}" \
+          --var-file "content:${TMPFILE}" \
           --template "{{ .Vars.content | AvoidHTMLEscape }}"
+
+        # Clean up temp file
+        rm -f "${TMPFILE}"

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,42 @@
+name: 'Sticky Comment'
+description: 'Post sticky comments to GitHub PRs and Issues using github-comment CLI'
+author: 'haya14busa'
+branding:
+  icon: 'message-square'
+  color: 'blue'
+
+inputs:
+  key:
+    description: 'Unique key for the sticky comment (used for updating)'
+    required: true
+  body:
+    description: 'Comment body content'
+    required: true
+  number:
+    description: 'PR or Issue number. If not provided, will be auto-detected from the context'
+    required: false
+    default: ''
+  token:
+    description: 'GitHub token'
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Post sticky comment
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        COMMENT_KEY: ${{ inputs.key }}
+        COMMENT_BODY: ${{ inputs.body }}
+        COMMENT_NUMBER: ${{ inputs.number }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        # Run github-comment
+        "${ACTION_PATH}/run-github-comment.sh" -- post \
+          --pr "${COMMENT_NUMBER}" \
+          -k "${COMMENT_KEY}" \
+          --update-condition "Comment.HasMeta && Comment.Meta.TemplateKey == \"${COMMENT_KEY}\"" \
+          --var "content:${COMMENT_BODY}" \
+          --template "{{ .Vars.content | AvoidHTMLEscape }}"

--- a/action.yml
+++ b/action.yml
@@ -33,12 +33,9 @@ runs:
         COMMENT_NUMBER: ${{ inputs.number }}
         ACTION_PATH: ${{ github.action_path }}
       run: |
-        # Set PR number to 0 if not provided (github-comment will auto-detect)
-        PR_NUMBER="${COMMENT_NUMBER:-0}"
-
         # Run github-comment
         "${ACTION_PATH}/run-github-comment.sh" -- post \
-          --pr "${PR_NUMBER}" \
+          --pr "${COMMENT_NUMBER:-0}" \
           -k "${COMMENT_KEY}" \
           --update-condition "Comment.HasMeta && Comment.Meta.TemplateKey == \"${COMMENT_KEY}\"" \
           --var "content:${COMMENT_BODY}" \

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,7 @@ runs:
         COMMENT_NUMBER: ${{ inputs.number }}
         ACTION_PATH: ${{ github.action_path }}
       run: |
+        set -x  # Show executed commands for debugging
         # Run github-comment
         "${ACTION_PATH}/run-github-comment.sh" -- post \
           --pr "${COMMENT_NUMBER:-0}" \

--- a/action.yml
+++ b/action.yml
@@ -33,19 +33,20 @@ runs:
         COMMENT_NUMBER: ${{ inputs.number }}
         ACTION_PATH: ${{ github.action_path }}
       run: |
+        set -euo pipefail
         set -x  # Show executed commands for debugging
 
         # Create temp file for comment body
         TMPFILE=$(mktemp)
         echo "${COMMENT_BODY}" > "${TMPFILE}"
 
-        # Run github-comment
+        # Run github-comment (avoid spaces in args to prevent wrapper splitting)
         "${ACTION_PATH}/run-github-comment.sh" -- post \
           --pr "${COMMENT_NUMBER:-0}" \
           -k "${COMMENT_KEY}" \
-          --update-condition "Comment.HasMeta && Comment.Meta.TemplateKey == \"${COMMENT_KEY}\"" \
+          --update-condition "Comment.HasMeta&&Comment.Meta.TemplateKey==\"${COMMENT_KEY}\"" \
           --var-file "content:${TMPFILE}" \
-          --template '{{ .Vars.content | AvoidHTMLEscape }}'
+          --template '{{.Vars.content|AvoidHTMLEscape}}'
 
         # Clean up temp file
         rm -f "${TMPFILE}"

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
           -k "${COMMENT_KEY}" \
           --update-condition "Comment.HasMeta && Comment.Meta.TemplateKey == \"${COMMENT_KEY}\"" \
           --var-file "content:${TMPFILE}" \
-          --template "{{ .Vars.content | AvoidHTMLEscape }}"
+          --template '{{ .Vars.content | AvoidHTMLEscape }}'
 
         # Clean up temp file
         rm -f "${TMPFILE}"

--- a/action.yml
+++ b/action.yml
@@ -33,9 +33,12 @@ runs:
         COMMENT_NUMBER: ${{ inputs.number }}
         ACTION_PATH: ${{ github.action_path }}
       run: |
+        # Set PR number to 0 if not provided (github-comment will auto-detect)
+        PR_NUMBER="${COMMENT_NUMBER:-0}"
+
         # Run github-comment
         "${ACTION_PATH}/run-github-comment.sh" -- post \
-          --pr "${COMMENT_NUMBER}" \
+          --pr "${PR_NUMBER}" \
           -k "${COMMENT_KEY}" \
           --update-condition "Comment.HasMeta && Comment.Meta.TemplateKey == \"${COMMENT_KEY}\"" \
           --var "content:${COMMENT_BODY}" \


### PR DESCRIPTION
## Summary

- Create a composite action for posting sticky comments to GitHub PRs and Issues
- Uses github-comment CLI with automatic template escaping
- Supports both PRs and Issues with auto-detection of PR/Issue numbers

## Features

- **Simple interface**: Just pass `key` and `body` parameters
- **Template escaping**: Automatically handles Go template syntax in markdown content
- **Sticky comments**: Updates existing comments with the same key instead of creating duplicates
- **Secure**: All inputs are passed via environment variables to prevent injection attacks

## Test plan

- [ ] Test posting a comment to a PR
- [ ] Test updating an existing comment with the same key
- [ ] Verify template characters like `{{` and `}}` are properly escaped

🤖 Generated with [Claude Code](https://claude.ai/code)