### PR TITLE
Fix action failure propagation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,11 @@ runs:
 
         # Create temp file for comment body
         TMPFILE=$(mktemp)
+
+        # Ensure cleanup on exit
+        trap 'rm -f "${TMPFILE}"' EXIT
+
+        # Write comment body to temp file
         echo "${COMMENT_BODY}" > "${TMPFILE}"
 
         # Run github-comment
@@ -47,6 +52,3 @@ runs:
           --update-condition "Comment.HasMeta && Comment.Meta.TemplateKey == \"${COMMENT_KEY}\"" \
           --var-file "content:${TMPFILE}" \
           --template '{{.Vars.content | AvoidHTMLEscape}}'
-
-        # Clean up temp file
-        rm -f "${TMPFILE}"


### PR DESCRIPTION
## Summary
This PR ensures that the GitHub Action properly fails when `github-comment` CLI fails.

## Problem
The action might not properly propagate failures from the `run-github-comment.sh` script, causing workflows to continue even when the comment posting fails.

## Solution
- Use `trap` to ensure temp file cleanup happens even on script failure
- With `set -euo pipefail` already in place, the script will properly exit with non-zero code when `run-github-comment.sh` fails
- This ensures the GitHub Action step is marked as failed when github-comment fails

## Test plan
- [ ] Test with valid comment posting (should succeed)
- [ ] Test with invalid GitHub token (should fail and mark action as failed)
- [ ] Test with invalid PR number (should fail and mark action as failed)
- [ ] Verify temp file is cleaned up in both success and failure cases

🤖 Generated with [Claude Code](https://claude.ai/code)