### PR TITLE
feat: Add skip-no-token support for fork-friendly PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           key: 'test-pr-comment'
           body: test comment (will be updated with next step)
+          skip-no-token: 'true'
 
       - name: Post sticky comment
         uses: ./
@@ -32,6 +33,7 @@ jobs:
             - Timestamp: ${{ github.event.pull_request.updated_at }}
 
             This comment should update on each push, not create duplicates.
+          skip-no-token: 'true'
 
       - name: Post another sticky comment with different key
         uses: ./
@@ -45,3 +47,39 @@ jobs:
             - Actor: ${{ github.actor }}
 
             Testing template escaping: {{ this should not be interpreted as a template }}
+          skip-no-token: 'true'
+
+  test-without-permissions:
+    runs-on: ubuntu-latest
+    # No permissions specified - tests behavior when no token is available
+    permissions: {}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test with skip-no-token enabled (should succeed in dry-run mode)
+        uses: ./
+        with:
+          key: 'test-no-perms'
+          body: |
+            This test runs without permissions.
+            With skip-no-token enabled, it should succeed in dry-run mode.
+          skip-no-token: 'true'
+
+      - name: Test without skip-no-token (should fail)
+        uses: ./
+        continue-on-error: true
+        id: should-fail
+        with:
+          key: 'test-no-perms-fail'
+          body: |
+            This test runs without permissions and without skip-no-token.
+            It should fail.
+          skip-no-token: 'false'
+
+      - name: Verify previous step failed
+        run: |
+          if [ "${{ steps.should-fail.outcome }}" != "failure" ]; then
+            echo "Error: Step should have failed but outcome was: ${{ steps.should-fail.outcome }}"
+            exit 1
+          fi
+          echo "✅ Step failed as expected"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
           body: |
             This test runs without permissions.
             With skip-no-token enabled, it should succeed in dry-run mode.
+          token: ''  # Explicitly set to empty string
           skip-no-token: 'true'
 
       - name: Test without skip-no-token (should fail)
@@ -74,6 +75,7 @@ jobs:
           body: |
             This test runs without permissions and without skip-no-token.
             It should fail.
+          token: ''  # Explicitly set to empty string
           skip-no-token: 'false'
 
       - name: Verify previous step failed

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'GitHub token'
     required: false
     default: ${{ github.token }}
+  skip-no-token:
+    description: 'Works like dry-run if the GitHub Access Token is not set (instead of failing)'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -31,6 +35,7 @@ runs:
         COMMENT_KEY: ${{ inputs.key }}
         COMMENT_BODY: ${{ inputs.body }}
         COMMENT_NUMBER: ${{ inputs.number }}
+        SKIP_NO_TOKEN: ${{ inputs.skip-no-token }}
         ACTION_PATH: ${{ github.action_path }}
       run: |
         set -euo pipefail
@@ -45,10 +50,20 @@ runs:
         # Write comment body to temp file
         echo "${COMMENT_BODY}" > "${TMPFILE}"
 
-        # Run github-comment
-        "${ACTION_PATH}/run-github-comment.sh" -- post \
-          --pr "${COMMENT_NUMBER:-0}" \
-          -k "${COMMENT_KEY}" \
-          --update-condition "Comment.HasMeta && Comment.Meta.TemplateKey == \"${COMMENT_KEY}\"" \
-          --var-file "content:${TMPFILE}" \
+        # Build command arguments
+        ARGS=(
+          post
+          --pr "${COMMENT_NUMBER:-0}"
+          -k "${COMMENT_KEY}"
+          --update-condition "Comment.HasMeta && Comment.Meta.TemplateKey == \"${COMMENT_KEY}\""
+          --var-file "content:${TMPFILE}"
           --template '{{.Vars.content | AvoidHTMLEscape}}'
+        )
+
+        # Add skip-no-token flag if enabled
+        if [ "${SKIP_NO_TOKEN}" = "true" ]; then
+          ARGS+=(--skip-no-token)
+        fi
+
+        # Run github-comment
+        "${ACTION_PATH}/run-github-comment.sh" -- "${ARGS[@]}"

--- a/action.yml
+++ b/action.yml
@@ -31,15 +31,20 @@ runs:
     - name: Post sticky comment
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.token }}
         COMMENT_KEY: ${{ inputs.key }}
         COMMENT_BODY: ${{ inputs.body }}
         COMMENT_NUMBER: ${{ inputs.number }}
         SKIP_NO_TOKEN: ${{ inputs.skip-no-token }}
         ACTION_PATH: ${{ github.action_path }}
+        INPUT_TOKEN: ${{ inputs.token }}
       run: |
         set -euo pipefail
         set -x  # Show executed commands for debugging
+
+        # Only set GITHUB_TOKEN if a token was provided and is not empty
+        if [ -n "${INPUT_TOKEN}" ]; then
+          export GITHUB_TOKEN="${INPUT_TOKEN}"
+        fi
 
         # Create temp file for comment body
         TMPFILE=$(mktemp)


### PR DESCRIPTION
## Summary

- Adds a new `skip-no-token` input parameter to the action
- When enabled and no token is available, the action runs in dry-run mode instead of failing
- Makes the action more friendly for PRs from forks that don't have write permissions

## Motivation

PRs from forks often don't have write permissions to post comments. Previously, the action would fail in these cases. With this change, setting `skip-no-token: 'true'` allows the action to gracefully handle these scenarios by running in dry-run mode.

## Changes

1. **New `skip-no-token` input**: Optional parameter (default: `'false'`) that enables dry-run mode when no token is available
2. **Updated action logic**: Conditionally passes the `--skip-no-token` flag to the underlying github-comment CLI
3. **Test improvements**: 
   - All tests now use `skip-no-token: 'true'` to prevent failures on fork PRs
   - Added a new test job without permissions to verify the skip-no-token behavior

## Test plan

- [x] All existing tests pass with `skip-no-token: 'true'`
- [x] New test job verifies behavior without permissions
- [x] Backwards compatibility maintained (default is `'false'`)

🤖 Generated with [Claude Code](https://claude.ai/code)