### PR TITLE
Skip test workflow on PRs from forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test-comment:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
## Summary
- Add condition to test workflow to only run on PRs from the same repository
- Prevents permission errors when PRs come from forks

## Test plan
- [ ] Verify workflow runs on PRs from the same repository
- [ ] Verify workflow is skipped on PRs from forks

🤖 Generated with [Claude Code](https://claude.ai/code)